### PR TITLE
Add /sbin and /usr/sbin mount points for compatibility

### DIFF
--- a/winsup/cygwin/mount.h
+++ b/winsup/cygwin/mount.h
@@ -169,7 +169,9 @@ class mount_info
   int nmounts;
   mount_item mount[MAX_MOUNTS];
 
-  static bool got_usr_bin;
+  static bool got_root_bin;
+  static bool got_root_sbin;
+  static bool got_root_usr_sbin;
   static int root_idx;
 
   /* cygdrive_prefix is used as the root of the path automatically


### PR DESCRIPTION
This complements the `/bin` mount point with two more, `/sbin` and `/usr/sbin`, all of them pointing at `/usr/bin`. Both exist in ArchLinux's `filesystem` package as symlinks.