### PR TITLE
Interpret TERM=msys as: use your preferred TERM

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -859,7 +859,16 @@ environ_init (char **envp, int envc)
 	  char *eq = strchrnul (newp, '=');
 	  ucenv (newp, eq);	/* uppercase env vars which need it */
 	  if (*newp == 'T' && strncmp (newp, "TERM=", 5) == 0)
-	    sawTERM = 1;
+	    {
+	      /* backwards compatibility: override TERM=msys by TERM=cygwin */
+	      if (strcmp (newp + 5, "msys") == 0)
+		{
+		  free(newp);
+		  i--;
+		  continue;
+		}
+	      sawTERM = 1;
+	    }
 #ifdef __MSYS__
 	  else if (*newp == 'M' && strncmp (newp, "MSYS=", 5) == 0)
 	    parse_options (newp + 5);


### PR DESCRIPTION
With MSys1, it was necessary to set the TERM variable to "msys". To
allow for a smooth transition from MSys1 to MSys2, let's simply handle
TERM=msys as if the user had not specified TERM at all and wanted us to
use our preferred TERM value.

This ensures that users can use the keyboard bindings they are used to
even if they defined the environment variable `TERM` to `msys`.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>