### PR TITLE
Be more careful when convert()ing POSIX to Windows paths

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -519,7 +519,7 @@ void rp_convert(const char** from, const char* to, char** dst, const char* dsten
         posix_to_win32_path(it, real_to, dst, dstend);
     }
 
-    if (real_to != to) {
+    if (*dst != dstend && real_to != to) {
         **dst = *real_to;
         *dst += 1;
     }
@@ -567,6 +567,9 @@ void ppl_convert(const char** from, const char* to, char** dst, const char* dste
             prev_was_simc = 1;
             subp_convert(&beg, it, is_url, dst, dstend);
             is_url = 0;
+
+            if (*dst == dstend)
+	        break;
 
             **dst = ';';
             *dst += 1;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -282,6 +282,7 @@ const char* convert(char *dst, size_t dstlen, const char *src) {
         *dstit = '\0';
         return dst;
     }
+    *dstend = '\0';
 
     const char* srcit = src;
     const char* srcbeg = src;
@@ -551,6 +552,7 @@ void subp_convert(const char** from, const char* end, int is_url, char** dst, co
 }
 
 void ppl_convert(const char** from, const char* to, char** dst, const char* dstend) {
+    const char *orig_dst = *dst;
     const char* it = *from;
     const char* beg = it;
     int prev_was_simc = 0;
@@ -568,8 +570,10 @@ void ppl_convert(const char** from, const char* to, char** dst, const char* dste
             subp_convert(&beg, it, is_url, dst, dstend);
             is_url = 0;
 
-            if (*dst == dstend)
-	        break;
+            if (*dst == dstend) {
+                system_printf("Path cut off during conversion: %s\n", orig_dst);
+                break;
+            }
 
             **dst = ';';
             *dst += 1;

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -3492,12 +3492,12 @@ arg_heuristic_with_exclusions (char const * const arg, char const * exclusions, 
 
   size_t stack_len = arglen + MAX_PATH;
   char * stack_path = (char *)malloc (stack_len);
-  memset (stack_path, 0, MAX_PATH);
-  if (!stack_len)
+  if (!stack_path)
     {
       debug_printf ("out of stack space?");
       return (char *)arg;
     }
+  memset (stack_path, 0, MAX_PATH);
   convert (stack_path, stack_len - 1, arg);
   debug_printf ("convert()'ed: %s (length %d)\n.....->: %s", arg, arglen, stack_path);
   // Don't allocate memory if no conversion happened.

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -3490,7 +3490,9 @@ arg_heuristic_with_exclusions (char const * const arg, char const * exclusions, 
       exclusions += strlen (exclusions) + 1;
     }
 
-  size_t stack_len = arglen + MAX_PATH;
+  // Leave enough room for at least 16 path elements; we might be converting
+  // a path list.
+  size_t stack_len = arglen + 16 * MAX_PATH;
   char * stack_path = (char *)malloc (stack_len);
   if (!stack_path)
     {

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -3505,8 +3505,7 @@ arg_heuristic_with_exclusions (char const * const arg, char const * exclusions, 
     {
       return ((char *)arg);
     }
-  arg_result = (char *)malloc (strlen (stack_path)+1);
-  strcpy (arg_result, stack_path);
+  arg_result = (char *)realloc (stack_path, strlen (stack_path)+1);
   // Windows doesn't like empty entries in PATH env. variables (;;)
   char* semisemi = strstr(arg_result, ";;");
   while (semisemi)

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -3503,6 +3503,10 @@ arg_heuristic_with_exclusions (char const * const arg, char const * exclusions, 
   // Don't allocate memory if no conversion happened.
   if (!strcmp (arg, stack_path))
     {
+      if (arg != stack_path)
+        {
+          free (stack_path);
+        }
       return ((char *)arg);
     }
   arg_result = (char *)realloc (stack_path, strlen (stack_path)+1);


### PR DESCRIPTION
We have only limited space, and in particular when converting path lists and the buffer was prepared for only one path, we are prone to run out of space. That should be reported, though, and when running out of space, we need to stop adding characters.

This bug has been found through [this bug report](https://github.com/git-for-windows/git/issues/303) (the symptom was a cryptic "Bad access" error).