### PR TITLE
Add directory junction support

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -84,6 +84,15 @@ set_winsymlinks (const char *buf)
     allow_winsymlinks = WSYM_lnk;
   else if (ascii_strncasematch (buf, "lnk", 3))
     allow_winsymlinks = WSYM_lnk;
+  else if (ascii_strncasematch (buf, "safenative", 10))
+    {
+      if (ascii_strcasematch (buf + 10, "strict"))
+        allow_winsymlinks = WSYM_safenativestrict;
+      else if (ascii_strcasematch (buf + 10, "only"))
+        allow_winsymlinks = WSYM_safenativeonly;
+      else
+        allow_winsymlinks = WSYM_safenative;
+    }
   /* Make sure to try native symlinks only on systems supporting them. */
   else if (ascii_strncasematch (buf, "native", 6))
     {

--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -81,7 +81,7 @@ static void
 set_winsymlinks (const char *buf)
 {
   if (!buf || !*buf)
-    allow_winsymlinks = WSYM_lnk;
+    allow_winsymlinks = WSYM_safenative;
   else if (ascii_strncasematch (buf, "lnk", 3))
     allow_winsymlinks = WSYM_lnk;
   else if (ascii_strncasematch (buf, "safenative", 10))

--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -59,7 +59,10 @@ enum winsym_t
   WSYM_lnk,
   WSYM_native,
   WSYM_nativestrict,
-  WSYM_nfs
+  WSYM_nfs,
+  WSYM_safenative,
+  WSYM_safenativestrict,
+  WSYM_safenativeonly
 };
 
 exit_states NO_COPY exit_state;

--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -78,7 +78,7 @@ bool ignore_case_with_glob;
 bool pipe_byte;
 bool reset_com;
 bool wincmdln;
-winsym_t allow_winsymlinks = WSYM_sysfile;
+winsym_t allow_winsymlinks = WSYM_safenative;
 
 bool NO_COPY in_forkee;
 


### PR DESCRIPTION
This PR add support for directory junction creation as symlink.
Directory junction is supported since Win2k and do not require admin rights or UAC disable.
With new default symlink setting autotools' configure will use `ln -s` for symlinks instead of `cp -pR` which can speedup a lot building in some situations.
Note: Cygwin already is able to read junction, this PR add only support for creation.
Upstream patch: https://cygwin.com/ml/cygwin-patches/2015-q3/msg00028.html