### PR TITLE
Pass the TZ variable to non-MSYS2 programs when appropriate

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -1195,7 +1195,15 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
       {
 	/* Don't pass timezone environment to non-msys applications */
 	if (ascii_strncasematch(*srcp, "TZ=", 3))
-	  goto next1;
+          {
+	    const char *v = *srcp + 3;
+	    if (*v == ':')
+	      goto next1;
+	    for (; *v; v++)
+	      if (!isalpha(*v) && !isdigit(*v) &&
+		  *v != '-' && *v != '+' && *v != ':')
+	        goto next1;
+	  }
 	else if (ascii_strncasematch(*srcp, "MSYS2_ENV_CONV_EXCL=", 20))
 	  {
 	    msys2_env_conv_excl_env = (char*)alloca (strlen(&(*srcp)[20])+1);


### PR DESCRIPTION
As reported in https://gitter.im/msys2/msys2?at=5d09432af5cf1f10bca34149, there are circumstances where the `TZ` variable conforms to the format that non-MSYS2 programs can handle.

Besides, it seems that quite a number of open source projects' test suites rely on the ability to set `TZ` in a shell script that then launches a non-MSYS2 program that should see that variable.

This patch has been living in Git for Windows' flavor of the MSYS2 runtime for ages, without problems (and fixing Git's test suite).